### PR TITLE
Changes to report, salary and employee models

### DIFF
--- a/tests/fixtures/report/report_1.json
+++ b/tests/fixtures/report/report_1.json
@@ -1,6 +1,7 @@
 {
   "created":  "2008-09-15T15:53:00Z",
   "current_as_of": "2008-09-15T15:53:00Z",
+  "additional_notes": "xyz",
   "verification_request": {
     "id": "report_1",
     "type": "employment-income",
@@ -22,7 +23,7 @@
     "last_name": "Last",
     "status": "inactive",
     "hired_date": "2017-08-08",
-    "end_of_employment": "2019-08-08",
+    "termination_date": "2019-08-08",
     "social_security_number": "***-**-9999",
     "earnings": [
       {
@@ -64,7 +65,12 @@
     "salary": {
       "gross_pay": "30000.00",
       "pay_frequency": "annually",
-      "hours_per_week": "40"
+      "hours_per_week": "40",
+      "reduced_covid": "no"
+    },
+    "respondent": {
+      "title": "Some Title",
+      "full_name": "First Last"
     }
   }
 }

--- a/truework/employee.py
+++ b/truework/employee.py
@@ -12,7 +12,7 @@ class Employee(object):
     last_name = attrib()
     status = attrib()
     hired_date = attrib()
-    end_of_employment = attrib()
     earnings = attrib(type=List[Earnings])
     positions = attrib(type=List[Position])
     salary = attrib(type=Salary)
+    termination_date = attrib(default=None)

--- a/truework/report.py
+++ b/truework/report.py
@@ -4,6 +4,7 @@ from truework import VerificationRequest
 from truework.base import RetrievableAPIResource, APIClient
 from truework.employee import Employee
 from truework.employer import Employer
+from truework.respondent import Respondent
 
 
 @attrs(frozen=True)
@@ -22,3 +23,5 @@ class Report(RetrievableAPIResource):
     verification_request = attrib(type=VerificationRequest)
     employer = attrib(type=Employer)
     employee = attrib(type=Employee)
+    additional_notes = attrib(default=None)
+    respondent = attrib(type=Respondent, default=None)

--- a/truework/respondent.py
+++ b/truework/respondent.py
@@ -1,0 +1,7 @@
+from attr import attrs, attrib
+
+
+@attrs(frozen=True)
+class Respondent(object):
+    full_name = attrib(default=None)
+    address = attrib(default=None)

--- a/truework/salary.py
+++ b/truework/salary.py
@@ -6,3 +6,4 @@ class Salary(object):
     gross_pay = attrib()
     pay_frequency = attrib()
     hours_per_week = attrib()
+    reduced_covid = attrib(default=None)

--- a/truework/version.py
+++ b/truework/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.1"
+VERSION = "1.0.0"


### PR DESCRIPTION
- Backwards compatible changes:
  - Adding additional_notes and respondent to report model
  - Adding reduced_covid to Salary model

- Backwards incompatible changes:
  - Rename end_of_employment to termination_date in Employee model